### PR TITLE
Improvement on args of sisimai rise

### DIFF
--- a/sisimai/fact/lhost-code_test.go
+++ b/sisimai/fact/lhost-code_test.go
@@ -45,9 +45,9 @@ var Alternates = map[string][]string{
 	},
 }
 
-var ArgForRise = map[string]bool {"delivered": true, "vacation": true}
 var TestReturn = map[string]interface{}{"neko-dono": []string{"Michitsuna", "Suzu"}}
-var CallbackFn = func(arg *sis.CallbackArgs) map[string]interface{} { return TestReturn }
+var CallbackFn = func(arg *sis.CallbackArgs) (map[string]interface{}, error) { return TestReturn, nil }
+var ArgForRise = &sis.DecodingArgs{Delivered: true, Vacation: true, Callback1: CallbackFn}
 
 // EngineTest() is called from lhost/*_test.go, rhost/*_test.go, rfc3464/lib_test.go, arf/lib_test.go.
 func EngineTest(t *testing.T, enginename string, isexpected [][]IsExpected, publictest bool) {
@@ -123,7 +123,7 @@ func EngineTest(t *testing.T, enginename string, isexpected [][]IsExpected, publ
 						if emailthing.Size == 0 { t.Errorf("%s %s is empty", ee, ef); continue }; cx++
 
 						mesg = sisimoji.ToLF(mesg)
-						fact, nyaan := Rise(mesg, emailthing.Path, ArgForRise, CallbackFn)
+						fact, nyaan := Rise(mesg, emailthing.Path, ArgForRise)
 						if nyaan     != nil { t.Logf("%s %s", ee, nyaan[0].Error()) }; cx++
 						if len(fact) != 0   { sisi = append(sisi, fact...) }
 					}

--- a/sisimai/message/sift.go
+++ b/sisimai/message/sift.go
@@ -65,7 +65,13 @@ func sift(bf *sis.BeforeFact, hook interface{}) bool {
 	bf.Payload  = strings.ReplaceAll(bf.Payload, "\t", " ") // Replace all the TAB with " "
 
 	cfargument := &sis.CallbackArgs{Headers: bf.Headers, Payload: &bf.Payload}
-	cfreturned := hook.(func(*sis.CallbackArgs) map[string]interface{})(cfargument)
+	cvv, nyaan := hook.(func(*sis.CallbackArgs) (map[string]interface{}, error))(cfargument)
+	if nyaan != nil {
+		// Something wrong when the 1st callback function executed
+		ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+		bf.Errors = append(bf.Errors, ce)
+	}
+
 	havecalled := map[string]bool{}
 	localhostr := sis.RisingUnderway{}
 	modulename := ""
@@ -152,7 +158,7 @@ func sift(bf *sis.BeforeFact, hook interface{}) bool {
 	}
 	bf.RFC822 = makemap(&rfc822part.Header, false)
 	bf.Digest = localhostr.Digest
-	bf.Catch  = cfreturned
+	bf.Catch  = cvv
 
 	return true
 }

--- a/sisimai/sis/callback-args.go
+++ b/sisimai/sis/callback-args.go
@@ -9,7 +9,7 @@ package sis
 //  \____\__,_|_|_|_.__/ \__,_|\___|_|\_\/_/   \_\_|  \__, |___/
 //                                                    |___/     
 // CallbackArgs{} is an argument of the callback functions that are called at sisimai.Rise() and 
-// sisimai/message.sift()
+// sisimai/message.sift(). It is aliased to sisimai.CallbackArgs at the libsisimai.go
 type CallbackArgs struct {
 	Headers map[string][]string
 	Payload *string

--- a/sisimai/sis/decoding-args.go
+++ b/sisimai/sis/decoding-args.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 azumakuniyuki and sisimai development team, All rights reserved.
+// This software is distributed under The BSD 2-Clause License.
+package sis
+
+//  ____                     _ _                _                  
+// |  _ \  ___  ___ ___   __| (_)_ __   __ _   / \   _ __ __ _ ___ 
+// | | | |/ _ \/ __/ _ \ / _` | | '_ \ / _` | / _ \ | '__/ _` / __|
+// | |_| |  __/ (_| (_) | (_| | | | | | (_| |/ ___ \| | | (_| \__ \
+// |____/ \___|\___\___/ \__,_|_|_| |_|\__, /_/   \_\_|  \__, |___/
+//                                     |___/             |___/     
+// DecodingArgs{} is an argument of the sisimai.Rise() function
+type DecodingArgs struct {
+	Delivered bool // Include sis.Fact{}.Action = "delivered" records in the decoded data
+	Vacation  bool // Include sis.Fact{}.Reason = "vacation" records in the decoded data
+	Callback1 func(arg *CallbackArgs) (map[string]interface{}, error) // The 1st callback function
+	Callback2 func(arg *CallbackArgs) (bool, error)                   // The 2nd callback function
+}
+


### PR DESCRIPTION
- type alias at libsisimai.go (`sis.CallbackArgs`)
- use `sis.DecodingArgs` for sisimai.Rise()