### PR TITLE
Reduce fmt.Sprintf()

### DIFF
--- a/lhost/via-amazonses.go
+++ b/lhost/via-amazonses.go
@@ -257,7 +257,7 @@ func init() {
 		}
 		if whatnotify == "" {
 			// Failed to loadl/decode JSON
-			ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", jsonerrors), true); ce.DecodedBy = "AmazonSES"
+			ce := *sis.MakeNotDecoded(jsonerrors.Error(), true); ce.DecodedBy = "AmazonSES"
 			notdecoded = append(notdecoded, ce)
 			return &sis.RisingUnderway{Errors: notdecoded}
 		}

--- a/libsisimai.go
+++ b/libsisimai.go
@@ -14,7 +14,6 @@
 package sisimai
 
 import "io"
-import "fmt"
 import "errors"
 import "strings"
 import "libsisimai.org/sisimai/v5/sis"
@@ -53,7 +52,7 @@ func Rise(path string, args *sis.DecodingArgs) (*[]sis.Fact, *[]sis.NotDecoded) 
 	emailthing, nyaan := sisimbox.Rise(path); if nyaan != nil {
 		// The file does not exist, or is not a regular file.
 		ef := "<STDIN>"; if emailthing != nil { ef = emailthing.Path }
-		ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), true); ce.Email(ef)
+		ce := *sis.MakeNotDecoded(nyaan.Error(), true); ce.Email(ef)
 		notdecoded = append(notdecoded, ce)
 		return &sisidigest, &notdecoded
 	}
@@ -68,7 +67,7 @@ func Rise(path string, args *sis.DecodingArgs) (*[]sis.Fact, *[]sis.NotDecoded) 
 
 			} else {
 				// Something wrong, sisimai failed to read the email as a text
-				ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), true); ce.Email(emailthing.Path)
+				ce := *sis.MakeNotDecoded(nyaan.Error(), true); ce.Email(emailthing.Path)
 				notdecoded = append(notdecoded, ce)
 				continue
 			}
@@ -89,7 +88,7 @@ func Rise(path string, args *sis.DecodingArgs) (*[]sis.Fact, *[]sis.NotDecoded) 
 				// 2nd argument of Sisimai.Rise() after reading each email file every time
 				carg := &sis.CallbackArg1{Path: emailthing.Path, Kind: emailthing.Kind, Mail: mesg, Fact: facts}
 				if _, nyaan := args.Callback1(carg); nyaan != nil {
-					ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), true); ce.Email(emailthing.Path)
+					ce := *sis.MakeNotDecoded(nyaan.Error(), true); ce.Email(emailthing.Path)
 					notdecoded = append(notdecoded, ce)
 				}
 			}
@@ -114,7 +113,7 @@ func Dump(path string, args *sis.DecodingArgs) (*string, *[]sis.NotDecoded) {
 
 	for _, e := range *sisidigest {
 		cj, nyaan := e.Dump(); if nyaan != nil {
-			*notdecoded = append(*notdecoded, *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false))
+			*notdecoded = append(*notdecoded, *sis.MakeNotDecoded(nyaan.Error(), false))
 		}
 		if cj != "" { serialized = append(serialized, cj) }
 	}

--- a/message/rise.go
+++ b/message/rise.go
@@ -10,7 +10,6 @@
 package message
 
 import "io"
-import "fmt"
 import "strings"
 import "net/mail"
 import "libsisimai.org/sisimai/v5/sis"
@@ -37,7 +36,7 @@ func Rise(mesg *string, hook sis.CfParameter0) *sis.BeforeFact {
 		moji.ToLF(mesg)
 		if email, nyaan := mail.ReadMessage(strings.NewReader(*mesg)); nyaan != nil {
 			// Failed to read the message as an email
-			ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), true)
+			ce := *sis.MakeNotDecoded(nyaan.Error(), true)
 			beforefact.Errors = append(beforefact.Errors, ce)
 			return beforefact
 

--- a/message/sift.go
+++ b/message/sift.go
@@ -7,7 +7,6 @@
 //                                |___/      
 
 package message
-import "fmt"
 import "strings"
 import "net/mail"
 import "libsisimai.org/sisimai/v5/sis"
@@ -42,7 +41,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 			cv, nyaan := rfc2045.DecodeB(bf.Payload, ""); bf.Payload = cv
 			if nyaan != nil {
 				// Something wrong when the function decodes the BASE64 encoded string
-				ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+				ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 				bf.Errors = append(bf.Errors, ce)
 			}
 		} else if ctencoding == "quoted-printable" {
@@ -50,7 +49,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 			cv, nyaan := rfc2045.DecodeQ(bf.Payload); bf.Payload = cv
 			if nyaan != nil {
 				// Something wrong when the function decodes the Quoted-Printable encoded string
-				ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+				ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 				bf.Errors = append(bf.Errors, ce)
 			}
 		}
@@ -69,7 +68,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 		// Execute the first callback function
 		cvv, nyaan := hook(&sis.CallbackArg0{Headers: bf.Headers, Payload: &bf.Payload}); if nyaan != nil {
 			// Something wrong when the 1st callback function executed
-			ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+			ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 			bf.Errors = append(bf.Errors, ce)
 		}
 		bf.Catch = cvv
@@ -142,7 +141,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 	rfc822part, nyaan := mail.ReadMessage(strings.NewReader(rising.RFC822))
 	if nyaan != nil {
 		// Failed to read the original message part
-		ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+		ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 		bf.Errors = append(bf.Errors, ce)
 		return false
 	}

--- a/rfc2045/make-multipart-flat.go
+++ b/rfc2045/make-multipart-flat.go
@@ -7,7 +7,6 @@
 // |_| \_\_|   \____|_____|\___/   |_||____/ 
 
 package rfc2045
-import "fmt"
 import "strings"
 import "libsisimai.org/sisimai/v5/sis"
 import "libsisimai.org/sisimai/v5/moji"
@@ -214,7 +213,7 @@ func MakeFlat(argv0 string, argv1 *string) (*string, *[]sis.NotDecoded) {
 				cv, nyaan := DecodeB(bodyinside, ""); bodystring = cv
 				if nyaan != nil {
 					// Something wrong when the function decodes the BASE64 encoded string
-					ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+					ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 					*notdecoded = append(*notdecoded, ce)
 				}
 			} else if ctencoding == "quoted-printable" {
@@ -222,7 +221,7 @@ func MakeFlat(argv0 string, argv1 *string) (*string, *[]sis.NotDecoded) {
 				cv, nyaan := DecodeQ(bodyinside); bodystring = cv
 				if nyaan != nil {
 					// Something wrong when the function decodes the Quoted-Printable encoded string
-					ce := *sis.MakeNotDecoded(fmt.Sprintf("%s", nyaan), false)
+					ce := *sis.MakeNotDecoded(nyaan.Error(), false)
 					*notdecoded = append(*notdecoded, ce)
 				}
 			} else {


### PR DESCRIPTION
- Use `error.Error()` instead of `fmt.Sprintf()` to stringify an error message
- The former is faster than the latter

```
OK-2
goos: darwin
goarch: arm64
cpu: Apple M4
BenchmarkErrorError-10    	OK-2
OK-2
OK-2
OK-2
OK-2
42061858	        28.64 ns/op
OK-1
BenchmarkFmtSprintf-10    	OK-1
OK-1
OK-1
OK-1
17576601	        68.42 ns/op
PASS
ok  	command-line-arguments	3.499s
```