### PR TITLE
Fixed out of bounds read and updated go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module libsisimai.org/sisimai/v5
 
-go 1.17
+go 1.21

--- a/mail/lib.go
+++ b/mail/lib.go
@@ -199,7 +199,7 @@ func(this *EmailEntity) setNewLine() (bool, error) {
 	} else {
 		// Memory
 		if len(this.payload) ==  0 || this.payload[0] == "" { this.newline = 0; return false, nil }
-		readbuffer = this.payload[0][:1000]
+		readbuffer = this.payload[0][:min(1000, len(this.payload[0]))]
 	}
 
 	if strings.Contains(readbuffer, "\r\n")     { this.newline = 3; return true, nil }


### PR DESCRIPTION
If this.payload[0] is smaller than 1000, this results in a panic because of a out of bounds read.
This was fixed by limiting the read size to 1000 or the length of payload[0].

The go version was updated to 1.21 in order to use the built-in `min` function.