### PR TITLE
Remove the 2nd arg from rfc2045 decodeb

### DIFF
--- a/message/sift.go
+++ b/message/sift.go
@@ -38,7 +38,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 		// Content-Type: text/plain; charset=UTF-8
 		var nyaan error
 		switch ctencoding {
-			case "base64":           bf.Payload, nyaan = rfc2045.DecodeB(bf.Payload, "")
+			case "base64":           bf.Payload, nyaan = rfc2045.DecodeB(bf.Payload)
 			case "quoted-printable": bf.Payload, nyaan = rfc2045.DecodeQ(bf.Payload)
 		}
 		if nyaan != nil {

--- a/rfc2045/04-mime-decode_test.go
+++ b/rfc2045/04-mime-decode_test.go
@@ -18,12 +18,12 @@ func TestDecodeB(t *testing.T) {
 
 	for j, e := range be {
 		for _, f := range []string{"", "utf-8"} {
-			cv, ce := DecodeB(e, f)
+			cv, ce := DecodeB(e)
 			cx++; if cv != jp[j] { t.Errorf("%s(%s, %s) returns %s", fn, e, f, cv) }
 			cx++; if ce != nil   { t.Errorf("%s(%s, %s) returns error: %s", fn, e, f, ce) }
 		}
 	}
-	if cv, _ := DecodeB("", ""); cv != "" { t.Errorf("%s('') returns %s", fn, cv) }
+	if cv, _ := DecodeB(""); cv != "" { t.Errorf("%s('') returns %s", fn, cv) }
 
 	t.Logf("The number of tests = %d", cx)
 }

--- a/rfc2045/make-multipart-flat.go
+++ b/rfc2045/make-multipart-flat.go
@@ -204,7 +204,7 @@ func MakeFlat(ctype string, mpart *string) (*string, []sis.NotDecoded) {
 				// - https://github.com/sisimai/go-sisimai/issues/42
 				default: bodystring = bodyinside
 
-				case "base64":           bodystring, nyaan = DecodeB(bodyinside, "")
+				case "base64":           bodystring, nyaan = DecodeB(bodyinside)
 				case "quoted-printable": bodystring, nyaan = DecodeQ(bodyinside)
 			}
 			if nyaan != nil { notdecoded = append(notdecoded, *sis.MakeNotDecoded(nyaan.Error(), false)) }

--- a/rfc2045/mime-decode.go
+++ b/rfc2045/mime-decode.go
@@ -15,14 +15,13 @@ import "mime/quotedprintable"
 
 // DecodeB decodes Base64 encoded text.
 //   Arguments:
-//     - argv0 (string): Base64-Encoded text.
-//     - argv1 (string): Character set name.
+//     - text (string): Base64-Encoded text.
 //   Returns:
 //     - (string): Decoded text.
-func DecodeB(argv0 string, argv1 string) (string, error) {
-	if len(argv0) < 8 { return argv0, nil }
+func DecodeB(text string) (string, error) {
+	if len(text) < 8 { return text, nil }
 
-	base64text := strings.ReplaceAll(strings.TrimSpace(argv0), "\n", "")
+	base64text := strings.ReplaceAll(strings.TrimSpace(text), "\n", "")
 	cv, nyaan  := base64.StdEncoding.DecodeString(base64text); if nyaan != nil { return "", nyaan }
 	return string(cv), nil
 }


### PR DESCRIPTION
- Remove the 2nd argument of `rfc2045.DecodeB()` (`argv1` is unused)
- Change the 1st argument name: `argv0` to `text`