### PR TITLE
Remove 2nd arg from rfc5322 headers

### DIFF
--- a/arf/01-inquire_test.go
+++ b/arf/01-inquire_test.go
@@ -30,7 +30,7 @@ func TestIsARF(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 
@@ -52,7 +52,7 @@ func TestInquire(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/10-inquire-for-activehunter_test.go
+++ b/lhost/10-inquire-for-activehunter_test.go
@@ -30,7 +30,7 @@ func TestInquire10(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/12-inquire-for-amazonses_test.go
+++ b/lhost/12-inquire-for-amazonses_test.go
@@ -30,7 +30,7 @@ func TestInquire12(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/15-inquire-for-apachejames_test.go
+++ b/lhost/15-inquire-for-apachejames_test.go
@@ -30,7 +30,7 @@ func TestInquire15(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/18-inquire-for-biglobe_test.go
+++ b/lhost/18-inquire-for-biglobe_test.go
@@ -30,7 +30,7 @@ func TestInquire18(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/20-inquire-for-courier_test.go
+++ b/lhost/20-inquire-for-courier_test.go
@@ -30,7 +30,7 @@ func TestInquire20(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/21-inquire-for-domino_test.go
+++ b/lhost/21-inquire-for-domino_test.go
@@ -30,7 +30,7 @@ func TestInquire21(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/22-inquire-for-dragonfly_test.go
+++ b/lhost/22-inquire-for-dragonfly_test.go
@@ -37,7 +37,7 @@ func TestInquire22(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/23-inquire-for-einsundeins_test.go
+++ b/lhost/23-inquire-for-einsundeins_test.go
@@ -30,7 +30,7 @@ func TestInquire23(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/24-inquire-for-exchange2003_test.go
+++ b/lhost/24-inquire-for-exchange2003_test.go
@@ -31,7 +31,7 @@ func TestInquire24(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/25-inquire-for-exchange2007_test.go
+++ b/lhost/25-inquire-for-exchange2007_test.go
@@ -32,7 +32,7 @@ func TestInquire25(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/26-inquire-for-exim_test.go
+++ b/lhost/26-inquire-for-exim_test.go
@@ -38,7 +38,7 @@ func TestInquire26(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/27-inquire-for-ezweb_test.go
+++ b/lhost/27-inquire-for-ezweb_test.go
@@ -31,7 +31,7 @@ func TestInquire27(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/29-inquire-for-fml_test.go
+++ b/lhost/29-inquire-for-fml_test.go
@@ -30,7 +30,7 @@ func TestInquire29(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/30-inquire-for-gmail_test.go
+++ b/lhost/30-inquire-for-gmail_test.go
@@ -32,7 +32,7 @@ func TestInquire30(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/31-inquire-for-gmx_test.go
+++ b/lhost/31-inquire-for-gmx_test.go
@@ -30,7 +30,7 @@ func TestInquire31(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/32-inquire-for-googlegroups_test.go
+++ b/lhost/32-inquire-for-googlegroups_test.go
@@ -33,7 +33,7 @@ func TestInquire32(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/33-inquire-for-googleworkspace_test.go
+++ b/lhost/33-inquire-for-googleworkspace_test.go
@@ -30,7 +30,7 @@ func TestInquire33(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/34-inquire-for-imailserver_test.go
+++ b/lhost/34-inquire-for-imailserver_test.go
@@ -31,7 +31,7 @@ func TestInquire34(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/35-inquire-for-interscanmss_test.go
+++ b/lhost/35-inquire-for-interscanmss_test.go
@@ -30,7 +30,7 @@ func TestInquire35(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/36-inquire-for-kddi_test.go
+++ b/lhost/36-inquire-for-kddi_test.go
@@ -30,7 +30,7 @@ func TestInquire36(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/37-inquire-for-mailfoundry_test.go
+++ b/lhost/37-inquire-for-mailfoundry_test.go
@@ -30,7 +30,7 @@ func TestInquire37(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/38-inquire-for-mailmarshalsmtp_test.go
+++ b/lhost/38-inquire-for-mailmarshalsmtp_test.go
@@ -30,7 +30,7 @@ func TestInquire38(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/42-inquire-for-messagingserver_test.go
+++ b/lhost/42-inquire-for-messagingserver_test.go
@@ -33,7 +33,7 @@ func TestInquire42(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/43-inquire-for-mfilter_test.go
+++ b/lhost/43-inquire-for-mfilter_test.go
@@ -30,7 +30,7 @@ func TestInquire43(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/45-inquire-for-notes_test.go
+++ b/lhost/45-inquire-for-notes_test.go
@@ -30,7 +30,7 @@ func TestInquire45(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/46-inquire-for-opensmtpd_test.go
+++ b/lhost/46-inquire-for-opensmtpd_test.go
@@ -33,7 +33,7 @@ func TestInquire46(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/48-inquire-for-postfix_test.go
+++ b/lhost/48-inquire-for-postfix_test.go
@@ -43,7 +43,7 @@ func TestInquire48(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/50-inquire-for-qmail_test.go
+++ b/lhost/50-inquire-for-qmail_test.go
@@ -34,7 +34,7 @@ func TestInquire50(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/53-inquire-for-sendmail_test.go
+++ b/lhost/53-inquire-for-sendmail_test.go
@@ -41,7 +41,7 @@ func TestInquire53(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/55-inquire-for-v5sendmail_test.go
+++ b/lhost/55-inquire-for-v5sendmail_test.go
@@ -31,7 +31,7 @@ func TestInquire55(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/56-inquire-for-verizon_test.go
+++ b/lhost/56-inquire-for-verizon_test.go
@@ -30,7 +30,7 @@ func TestInquire56(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/57-inquire-for-x1_test.go
+++ b/lhost/57-inquire-for-x1_test.go
@@ -30,7 +30,7 @@ func TestInquire57(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/58-inquire-for-x2_test.go
+++ b/lhost/58-inquire-for-x2_test.go
@@ -30,7 +30,7 @@ func TestInquire58(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/59-inquire-for-x3_test.go
+++ b/lhost/59-inquire-for-x3_test.go
@@ -30,7 +30,7 @@ func TestInquire59(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/62-inquire-for-x6_test.go
+++ b/lhost/62-inquire-for-x6_test.go
@@ -30,7 +30,7 @@ func TestInquire62(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/lhost/65-inquire-for-zoho_test.go
+++ b/lhost/65-inquire-for-zoho_test.go
@@ -30,7 +30,7 @@ func TestInquire65(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/message/04-sift_test.go
+++ b/message/04-sift_test.go
@@ -31,7 +31,7 @@ func TestSift(t *testing.T) {
 	}
 
 	bf.Sender  = "MAILER-DAEMON Fri Feb  2 18:30:22 2018"
-	bf.Headers = rfc5322.Headers(&em.Header, false)
+	bf.Headers = rfc5322.Headers(&em.Header)
 	bf.Payload = string(eb)
 
 	cx++; if len(bf.Headers) == 0             { t.Errorf("rfc5322.Headers() returns empty headers") }

--- a/message/rise.go
+++ b/message/rise.go
@@ -52,7 +52,7 @@ func Rise(mesg *string, hook sis.CfParameter0) *sis.BeforeFact {
 			}
 
 			// Build "Head", "Body" members of BeforeFact
-			beforefact.Headers = rfc5322.Headers(&email.Header, false)
+			beforefact.Headers = rfc5322.Headers(&email.Header)
 			bodystring, nyaan := io.ReadAll(email.Body); if nyaan != nil { break RISE }
 			beforefact.Payload = string(bodystring)
 		}

--- a/message/sift.go
+++ b/message/sift.go
@@ -130,7 +130,7 @@ func sift(bf *sis.BeforeFact, hook sis.CfParameter0) bool {
 		bf.Errors = append(bf.Errors, ce)
 		return false
 	}
-	bf.RFC822 = rfc5322.Headers(&rfc822part.Header, false)
+	bf.RFC822 = rfc5322.Headers(&rfc822part.Header)
 	bf.Digest = rising.Digest
 
 	return true

--- a/rfc3464/01-inquire_test.go
+++ b/rfc3464/01-inquire_test.go
@@ -33,7 +33,7 @@ func TestInquire(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/rfc3834/01-inquire_test.go
+++ b/rfc3834/01-inquire_test.go
@@ -29,7 +29,7 @@ func TestInquire(t *testing.T) {
 		eo, _ := mail.ReadMessage(strings.NewReader(ee))
 		bo, _ := io.ReadAll(eo.Body)
 		bf    := &sis.BeforeFact{
-			Headers: rfc5322.Headers(&eo.Header, false),
+			Headers: rfc5322.Headers(&eo.Header),
 			Payload: string(bo),
 		}
 

--- a/rfc5322/08-headers_test.go
+++ b/rfc5322/08-headers_test.go
@@ -25,7 +25,7 @@ func TestHeaders(t *testing.T) {
 			cx++; t.Fatalf("os.ReadFile(%s) returns an empty string", ef)
 		}
 		et := string(bx); em, _ := mail.ReadMessage(strings.NewReader(et))
-		cv := Headers(&em.Header, false)
+		cv := Headers(&em.Header)
 
 		cx++; if len(cv) == 0 { t.Errorf("%s() returns empty", fn) }
 		for e := range cv {

--- a/rfc5322/headers.go
+++ b/rfc5322/headers.go
@@ -13,15 +13,14 @@ import "libsisimai.org/sisimai/v5/moji"
 
 // Headers converts a mail.Header struct to a map[string][]string.
 //   Arguments:
-//     - argv0 (*mail.Header): Email headers.
-//     - argv1 (bool):         Decode "Subject:" header or not.
+//     - heads (*mail.Header): Email headers.
 //   Returns:
 //     - (map[string][]string: Structured email header data.
-func Headers(argv0 *mail.Header, argv1 bool) map[string][]string {
+func Headers(heads *mail.Header) map[string][]string {
 	headermaps := map[string][]string{}
 	isrequired := []string{"from", "received", "message-id", "content-type", "subject"}
 
-	for e, v := range *argv0 {
+	for e, v := range *heads {
 		// Each key name is the lower-cased string, each value is an array ([]string{})
 		// The field name of an email header does not contain " "
 		f := strings.ToLower(e)
@@ -46,8 +45,6 @@ func Headers(argv0 *mail.Header, argv1 bool) map[string][]string {
 		// The following fields should be exist
 		if len(headermaps[e]) == 0 { headermaps[e] = []string{""} }
 	}
-	if headermaps["subject"][0] == "" || argv1 == false { return headermaps }
-
 	return headermaps
 }
 


### PR DESCRIPTION
- Remove the 2nd argument from `rfc5322.Headers`
- Remove the 2nd argument from the code calling `rfc5322.Headers`